### PR TITLE
Add Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+node_js:
+  - 0.12
+before_script:
+  - npm install grunt-cli -g
+  - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
+
 node_js:
   - 0.12
+
 before_script:
   - npm install grunt-cli -g
   - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,12 @@ node_js:
   - "6"
 env:
   - CXX=g++-4.8
-  
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8 
 before_script:
   - npm install grunt-cli -g
   - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - 0.12
+  - "6"
 
 before_script:
   - npm install grunt-cli -g

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: node_js
 
 node_js:
   - "6"
-
+env:
+  - CXX=g++-4.8
+  
 before_script:
   - npm install grunt-cli -g
   - npm install

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 HackerQueue
 =========
+[![Build Status](https://travis-ci.org/gsrajadh/HackerQueue.svg?branch=master)](https://travis-ci.org/gsrajadh/HackerQueue)
 
 Your favorite tech sites compiled down to topics you find interesting.
 

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -2,7 +2,7 @@ module.exports = function(grunt) {
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
     jshint: {
-      options: { jshintrc: '.jshintrc' },
+      options: { jshintrc: '.jshintrc', reporterOutput: "" },
       myFiles: ['routes/*.js', "public/app.js" , 'app.js']
     }
   });

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"mocha": "*",
 		"chai": "*",
 		"grunt": "~0.4.5",
-		"grunt-contrib-jshint": "~0.10.0",
+		"grunt-contrib-jshint": "^0.10.0",
 		"grunt-html-angular-validate": "~0.4.0"
 	}
 }


### PR DESCRIPTION
I have added Travis CI support for the application. You will need to modify the badge with your Repo URL after you turn on Travis CI support for your repo in the following line : 
```
+[![Build Status](https://travis-ci.org/gsrajadh/HackerQueue.svg?branch=master)](https://travis-ci.org/gsrajadh/HackerQueue)
```
Please let me know if you have any questions.