### PR TITLE
Enables kubernetes deployment of webserver

### DIFF
--- a/app.js
+++ b/app.js
@@ -28,7 +28,7 @@ app.get('/lnew', lobstersRoute.lnew);
 app.get('/rnew', redditRoute.rnew);
 
 app.get('/status', function (req, res) {
-  return res.status(200).send('ok')
+  return res.status(200).send('ok');
 });
 
 app.set('views', __dirname + '/views'); // sets dir

--- a/app.js
+++ b/app.js
@@ -28,7 +28,7 @@ app.get('/lnew', lobstersRoute.lnew);
 app.get('/rnew', redditRoute.rnew);
 
 app.get('/status', function (req, res) {
-  return res.status(404).send('ok')
+  return res.status(200).send('ok')
 });
 
 app.set('views', __dirname + '/views'); // sets dir

--- a/hackerqueue.yaml
+++ b/hackerqueue.yaml
@@ -4,7 +4,6 @@ metadata:
   name: hackerqueue
 
 ---
-
 kind: Pod
 apiVersion: v1
 metadata:
@@ -15,7 +14,7 @@ metadata:
 spec:
   containers:
     - name: hackerqueue-webserver-app
-      image: frankcashno/hackerqueue:e2fcbd12fbeb390a867ecf60acd70539303fce6a
+      image: frankcashno/hackerqueue:52d3ab0b1885184f96b23cb70f7091808d5a5196
       imagePullPolicy: Always
       ports:
       - containerPort: 3000
@@ -23,13 +22,13 @@ spec:
         httpGet:
           path: /status
           port: 3000
-        initialDelaySeconds: 5
+        initialDelaySeconds: 30
         periodSeconds: 10
       livenessProbe:
         httpGet:
           path: /status
           port: 3000
-        initialDelaySeconds: 3
+        initialDelaySeconds: 30
         periodSeconds: 3
       env:
       - name: DATABASE_URL

--- a/hackerqueue.yaml
+++ b/hackerqueue.yaml
@@ -16,6 +16,7 @@ spec:
   containers:
     - name: hackerqueue-webserver-app
       image: frankcashno/hackerqueue:e2fcbd12fbeb390a867ecf60acd70539303fce6a
+      imagePullPolicy: Always
       ports:
       - containerPort: 3000
       readinessProbe:
@@ -41,8 +42,13 @@ apiVersion: v1
 metadata:
   name: hackerqueue-webserver-service
   namespace: hackerqueue
+  labels:
+    app: hackerqueue
 spec:
+  ports:
+    - port: 80 # Default port for image
+      name: hackerqueue-webserver-http-port
+      targetPort: 3000
+      protocol: TCP
   selector:
     app: hackerqueue
-  ports:
-    - port: 3000 # Default port for image


### PR DESCRIPTION
<!-- Fill out this template to explain your pull request. -->	
	
# Related Issue	
<!-- Please link to any related GitHub Issue. -->	
<!-- If none, please create an issue -->

N/A

# Changes Proposed	
<!-- Describe the changes you've made so it's easier for the team to review. -->	

- Adds HC route on `/status`
- Adds a kube manifest for running pod w/o DB connection

#### Caveats	
<!-- If there is anything hacky or unique being added in your code please define it.--> 

Probably should manage DB connection via Kubernetes secrets